### PR TITLE
Remove dir_load_exn

### DIFF
--- a/native_toplevel/opttopdirs.ml
+++ b/native_toplevel/opttopdirs.ml
@@ -73,38 +73,6 @@ let _ = Hashtbl.add directive_table "cd" (Directive_string dir_cd)
 
 (* Load in-core a .cmxs file *)
 
-let load_file_exn ppf name0 =
-  let name =
-    try Some (Load_path.find name0)
-    with Not_found -> None
-  in
-  match name with
-  | None ->
-    let msg = Format.asprintf "File not found: %s@." name0 in
-    failwith msg
-  | Some name ->
-    let fn,tmp =
-      if Filename.check_suffix name ".cmx" || Filename.check_suffix name ".cmxa"
-      then
-        let cmxs = Filename.temp_file "caml" ".cmxs" in
-        Asmlink.link_shared ~ppf_dump:ppf [name] cmxs;
-        cmxs,true
-      else
-        name,false
-    in
-    let res =
-      try
-        Dynlink.loadfile fn;
-        Result.Ok ()
-      with
-      | Dynlink.Error (Module_already_loaded _) -> Result.Ok ()
-      | exn -> Result.Error exn
-    in
-    if tmp then (try Sys.remove fn with Sys_error _ -> ());
-    match res with
-    | Ok () -> ()
-    | Error exn -> raise exn
-
 let load_file ppf name0 =
   let name =
     try Some (Load_path.find name0)
@@ -140,8 +108,6 @@ let load_file ppf name0 =
     success
 
 let dir_load ppf name = ignore (load_file ppf name)
-
-let dir_load_exn name = load_file_exn name
 
 let _ = Hashtbl.add directive_table "load" (Directive_string (dir_load std_out))
 

--- a/native_toplevel/opttopdirs.mli
+++ b/native_toplevel/opttopdirs.mli
@@ -22,7 +22,6 @@ val dir_directory : string -> unit
 val dir_remove_directory : string -> unit
 val dir_cd : string -> unit
 val dir_load : formatter -> string -> unit
-val dir_load_exn : formatter -> string -> unit
 val dir_use : formatter -> string -> unit
 val dir_use_output : formatter -> string -> unit
 val dir_install_printer : formatter -> Longident.t -> unit


### PR DESCRIPTION
This was added to improve `#require` error reporting in MDX. Since JS makes no use of this we can remove it for now, eventually
adding it back once it's been cleaned up as this was a quick and dirty implementation.