### PR TITLE
Expose toplevel internals used by the JIT

### DIFF
--- a/native_toplevel/opttoploop.mli
+++ b/native_toplevel/opttoploop.mli
@@ -169,3 +169,9 @@ end
 val register_jit : Jit.t -> unit
 
 val default_lookup : string -> Obj.t option
+
+(* Internals required by the JIT *)
+
+val need_symbol : string -> bool
+
+val phrase_name : string ref


### PR DESCRIPTION
These were marked as simply needed for experimentation in the jit-hook-411 branch but were actually required to properly run the
JIT.