### PR TITLE
Stop freshening bound identifiers when printing

### DIFF
--- a/middle_end/flambda2/nominal/name_abstraction.ml
+++ b/middle_end/flambda2/nominal/name_abstraction.ml
@@ -38,6 +38,14 @@ let[@inline always] pattern_match_pair ~freshen_bindable ~swap_bindable
 
 let print ~print_bindable ~print_term ~freshen_bindable ~swap_bindable
     ~apply_renaming_term ppf t =
+  let freshen_bindable, swap_bindable, apply_renaming_term =
+    if Flambda_features.freshen_when_printing ()
+    then freshen_bindable, swap_bindable, apply_renaming_term
+    else
+      ( (fun bindable -> bindable),
+        (fun _bindable ~guaranteed_fresh:_ -> Renaming.empty),
+        fun term _renaming -> term )
+  in
   pattern_match ~freshen_bindable ~swap_bindable ~apply_renaming_term t
     ~f:(fun bindable term ->
       Format.fprintf ppf "@[<hov 1>%s@<1>[%s%a%s@<1>%s]@ %a@]"

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -64,6 +64,8 @@ let dump_flexpect () = !Clflags.Flambda2.Dump.flexpect
 
 let dump_closure_offsets () = !Clflags.Flambda2.Dump.closure_offsets
 
+let freshen_when_printing () = !Clflags.Flambda2.Dump.freshen
+
 module Inlining = struct
   module I = Clflags.Int_arg_helper
   module F = Clflags.Float_arg_helper

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -62,6 +62,8 @@ val dump_flexpect : unit -> bool
 
 val dump_closure_offsets : unit -> bool
 
+val freshen_when_printing : unit -> bool
+
 module Inlining : sig
   val max_depth : round:int -> int
 

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -1207,6 +1207,10 @@ let mk_dclosure_offsets f =
   "-dclosure-offsets", Arg.Unit f, " Dump closure offsets (Flambda 2 only)"
 ;;
 
+let mk_dfreshen f =
+  "-dfreshen", Arg.Unit f, " Freshen bound names when printing (Flambda 2 only)"
+;;
+
 module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
@@ -1460,6 +1464,7 @@ module type Optcommon_options = sig
   val _dfexpr : unit -> unit
   val _dflexpect : unit -> unit
   val _dclosure_offsets : unit -> unit
+  val _dfreshen : unit -> unit
 end;;
 
 module type Optcomp_options = sig
@@ -1878,6 +1883,7 @@ struct
     mk_dfexpr F._dfexpr;
     mk_dflexpect F._dflexpect;
     mk_dclosure_offsets F._dclosure_offsets;
+    mk_dfreshen F._dfreshen;
     mk_dcfg F._dcfg;
     mk_dcmm F._dcmm;
     mk_dsel F._dsel;
@@ -2043,6 +2049,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dfexpr F._dfexpr;
     mk_dflexpect F._dflexpect;
     mk_dclosure_offsets F._dclosure_offsets;
+    mk_dfreshen F._dfreshen;
 
     mk_dsource F._dsource;
     mk_dparsetree F._dparsetree;
@@ -2431,6 +2438,7 @@ module Default = struct
     let _dfexpr = set Flambda2.Dump.fexpr
     let _dflexpect = set Flambda2.Dump.flexpect
     let _dclosure_offsets = set Flambda2.Dump.closure_offsets
+    let _dfreshen = set Flambda2.Dump.freshen
   end
 
   module Compiler = struct

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -268,6 +268,7 @@ module type Optcommon_options = sig
   val _dfexpr : unit -> unit
   val _dflexpect : unit -> unit
   val _dclosure_offsets : unit -> unit
+  val _dfreshen : unit -> unit
 end;;
 
 module type Optcomp_options = sig

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -486,6 +486,7 @@ module Flambda2 = struct
     let fexpr = ref false
     let flexpect = ref false
     let closure_offsets = ref false
+    let freshen = ref false
   end
 
   module Expert = struct

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -242,6 +242,7 @@ module Flambda2 : sig
     val fexpr : bool ref
     val flexpect : bool ref
     val closure_offsets : bool ref
+    val freshen : bool ref
   end
 
   module Expert : sig


### PR DESCRIPTION
The additional -dfreshen command-line flag restores the old behaviour.