### PR TITLE
Don't apply coercions deeply (except for closures)

### DIFF
--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -965,6 +965,10 @@ struct
   let mapi f t =
     fold (fun key datum result -> add key (f key datum) result) t empty
 
+  (* CR lmaurer: Implement this one properly even if [map] isn't efficient yet,
+     since not sharing makes _other things_ (including row-like types) less
+     efficient. *)
+
   let map_sharing = map
 
   let to_seq t =


### PR DESCRIPTION
Coercions only apply to their own domains - that is, a coercion on
closures doesn't apply to pairs (which might contain, say, a closure
and an int). So we don't want to recurse into types in general when
applying coercions. Unfortunately, the situation with closures is
... complicated, as explained in comments.