### PR TITLE
Small fixes around coercions and rec info

### DIFF
--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -80,6 +80,19 @@ let simplify_project_var closure_id closure_element ~min_name_mode dacc
     let env_extension = TEE.one_equation (Name.var result_var') ty in
     Simplified_named.invalid (), env_extension, dacc
   | Proved simple ->
+    (* Owing to the semantics of [Simplify_set_of_closures] when computing the
+       types of closure variables -- in particular because it allows depth
+       variables to exist in such types that are not in scope in the body of the
+       function -- we need to ensure that any [Simple] retrieved here from the
+       closure environment is simplified. This will ensure that if it is not in
+       scope, any associated coercion will be erased appropriately. *)
+    let simple =
+      if Coercion.is_id (Simple.coercion simple)
+      then simple
+      else
+        let ty = S.simplify_simple dacc simple ~min_name_mode in
+        T.get_alias_exn ty
+    in
     let reachable = Simplified_named.reachable (Named.create_simple simple) in
     let env_extension =
       TEE.one_equation (Name.var result_var') (T.alias_type_of K.value simple)

--- a/middle_end/flambda2/term_basics/rec_info_expr.ml
+++ b/middle_end/flambda2/term_basics/rec_info_expr.ml
@@ -34,7 +34,7 @@ let rec apply_renaming orig perm =
 let rec free_names_in_mode t mode =
   match t with
   | Const _ -> Name_occurrences.empty
-  | Var dv -> Name_occurrences.singleton_variable dv Name_mode.normal
+  | Var dv -> Name_occurrences.singleton_variable dv mode
   | Succ t | Unroll_to (_, t) -> free_names_in_mode t mode
 
 let free_names t = free_names_in_mode t Name_mode.normal

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -891,11 +891,7 @@ and add_equation t name ty ~(meet_type : meet_type) =
   let coercion_from_ty_to_bare_lhs =
     Coercion.inverse coercion_from_bare_lhs_to_ty
   in
-  let ty =
-    match TG.apply_coercion ty coercion_from_ty_to_bare_lhs with
-    | Bottom -> MTC.bottom (TG.kind ty)
-    | Ok ty -> ty
-  in
+  let ty = TG.apply_coercion ty coercion_from_ty_to_bare_lhs in
   (* Beware: if we're about to add the equation on a name which is different
      from the one that the caller passed in, then we need to make sure that the
      type we assign to that name is the most precise available. This
@@ -1054,10 +1050,7 @@ let type_simple_in_term_exn t ?min_name_mode simple =
   in
   let ty =
     if Simple.has_coercion simple
-    then
-      match (TG.apply_coercion ty (Simple.coercion simple) : _ Or_bottom.t) with
-      | Ok ty -> ty
-      | Bottom -> MTC.bottom (TG.kind ty)
+    then TG.apply_coercion ty (Simple.coercion simple)
     else ty
   in
   let kind = TG.kind ty in

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -266,7 +266,7 @@ val make_suitable_for_environment :
   bind_to:Name.t ->
   Typing_env_extension.With_extra_variables.t
 
-val apply_coercion : flambda_type -> Coercion.t -> flambda_type Or_bottom.t
+val apply_coercion : flambda_type -> Coercion.t -> flambda_type
 
 (** Construct a bottom type of the given kind. *)
 val bottom : Flambda_kind.t -> t

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -488,7 +488,7 @@ and free_names_function_type (function_type : _ Or_unknown_or_bottom.t) =
   match function_type with
   | Bottom | Unknown -> Name_occurrences.empty
   | Ok { code_id; rec_info } ->
-    Name_occurrences.add_code_id (free_names rec_info) code_id Name_mode.normal
+    Name_occurrences.add_code_id (free_names rec_info) code_id Name_mode.in_types
 
 and free_names_env_extension { equations } =
   Name.Map.fold

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -128,7 +128,7 @@ val kind : t -> Flambda_kind.t
 
 val alias_type_of : Flambda_kind.t -> Simple.t -> t
 
-val apply_coercion : t -> Coercion.t -> t Or_bottom.t
+val apply_coercion : t -> Coercion.t -> t
 
 val get_alias_exn : t -> Simple.t
 

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -37,9 +37,7 @@ let add_equation (simple : Simple.t) ty_of_simple env_extension =
       Coercion.inverse coercion_from_name_to_simple
     in
     let ty_of_name =
-      match TG.apply_coercion ty_of_simple coercion_from_simple_to_name with
-      | Ok ty -> ty
-      | Bottom -> MTC.bottom_like ty_of_simple
+      TG.apply_coercion ty_of_simple coercion_from_simple_to_name
     in
     TEE.add_or_replace_equation env_extension name ty_of_name
   | None -> env_extension


### PR DESCRIPTION
`Rec_info_expr` was failing to report free names in the given mode;
`Type_grammar` was failing to give `Rec_info_expr` the correct mode;
and coercion applications should just throw fatal errors rather than
returning bottom.