### PR TITLE
Better handling of mutable prim free names in flow analysis

### DIFF
--- a/middle_end/flambda2/simplify/flow/data_flow_graph.ml
+++ b/middle_end/flambda2/simplify/flow/data_flow_graph.ml
@@ -246,16 +246,6 @@ let add_name_occurrences name_occurrences
   in
   { t with unconditionally_used; code_id_unconditionally_used }
 
-let mutable_prim_free_names (mutable_prim : T.Mutable_prim.t) :
-    Name_occurrences.t =
-  match mutable_prim with
-  | Is_int block | Get_tag block | Block_load { block; _ } ->
-    Name_occurrences.singleton_variable block Name_mode.normal
-  | Block_set { block; value; _ } ->
-    Name_occurrences.add_variable (Simple.free_names value) block
-      Name_mode.normal
-  | Make_block { fields; _ } -> Simple.List.free_names fields
-
 let add_continuation_info map ~return_continuation ~exn_continuation
     ~used_value_slots _
     T.Continuation_info.
@@ -321,15 +311,18 @@ let add_continuation_info map ~return_continuation ~exn_continuation
   in
   let t =
     List.fold_left
-      (fun t T.Mutable_let_prim.{ bound_var; prim; named_rewrite_id = _ } ->
+      (fun t
+           T.Mutable_let_prim.
+             { bound_var; prim; original_prim; named_rewrite_id = _ } ->
         let src = Name.var bound_var in
         match prim with
         | Is_int _ | Get_tag _ | Make_block _ | Block_load _ ->
           Name_occurrences.fold_names
             ~f:(fun t dst -> add_dependency ~src ~dst t)
-            (mutable_prim_free_names prim)
+            (Flambda_primitive.free_names original_prim)
             ~init:t
-        | Block_set _ -> add_name_occurrences (mutable_prim_free_names prim) t)
+        | Block_set _ ->
+          add_name_occurrences (Flambda_primitive.free_names original_prim) t)
       t mutable_let_prims_rev
   in
   let t =

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -144,10 +144,10 @@ let record_var_alias var definition t =
       let defined = Variable.Set.add var elt.defined in
       { elt with direct_aliases; defined })
 
-let record_ref_named named_rewrite_id ~bound_to prim (t : t) =
+let record_ref_named named_rewrite_id ~bound_to original_prim prim (t : t) =
   update_top_of_stack ~t ~f:(fun cont_info ->
       let mutable_let_prim : T.Mutable_let_prim.t =
-        { bound_var = bound_to; named_rewrite_id; prim }
+        { bound_var = bound_to; named_rewrite_id; original_prim; prim }
       in
       let mutable_let_prims_rev =
         mutable_let_prim :: cont_info.mutable_let_prims_rev
@@ -357,21 +357,21 @@ let record_let_binding ~rewrite_id ~generate_phantom_lets ~let_bound
         match Simple.must_be_var simple with
         | Some (v, _) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var (Is_int v) t)
+            (record_ref_named rewrite_id ~bound_to:var prim (Is_int v) t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Unary (Get_tag, simple) -> (
         match Simple.must_be_var simple with
         | Some (v, _) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var (Get_tag v) t)
+            (record_ref_named rewrite_id ~bound_to:var prim (Get_tag v) t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Binary (Block_load (bak, mut), block, field) -> (
         match get_block_and_constant_field ~block ~field with
         | Some (block, field) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var
+            (record_ref_named rewrite_id ~bound_to:var prim
                (Block_load { bak; mut; block; field })
                t)
             Name_occurrences.empty
@@ -379,19 +379,16 @@ let record_let_binding ~rewrite_id ~generate_phantom_lets ~let_bound
       | Ternary (Block_set (bak, _), block, field, value) -> (
         match get_block_and_constant_field ~block ~field with
         | Some (block, field) ->
-          record_ref_named rewrite_id ~bound_to:var
+          record_ref_named rewrite_id ~bound_to:var prim
             (Block_set { bak; block; field; value })
             t
         | None -> add_used_in_current_handler free_names t)
       | Variadic (Make_block (kind, mut, alloc_mode), fields) ->
         record_var_bindings
-          (record_ref_named rewrite_id ~bound_to:var
+          (record_ref_named rewrite_id ~bound_to:var prim
              (Make_block { kind; mut; alloc_mode; fields })
              t)
           Name_occurrences.empty
-      | Unary (Begin_try_region, _) ->
-        let t = record_defined_var var t in
-        add_used_in_current_handler free_names t
       | _ ->
         if Flambda_primitive.at_most_generative_effects prim
         then (* the primitive can be removed *)

--- a/middle_end/flambda2/simplify/flow/flow_types.ml
+++ b/middle_end/flambda2/simplify/flow/flow_types.ml
@@ -81,10 +81,11 @@ module Mutable_let_prim = struct
   type t =
     { bound_var : Variable.t;
       prim : Mutable_prim.t;
+      original_prim : Flambda_primitive.t;
       named_rewrite_id : Named_rewrite_id.t
     }
 
-  let print ppf { bound_var; prim; named_rewrite_id = _ } =
+  let print ppf { bound_var; prim; original_prim = _; named_rewrite_id = _ } =
     Format.fprintf ppf "%a = %a" Variable.print bound_var Mutable_prim.print
       prim
 

--- a/middle_end/flambda2/simplify/flow/flow_types.mli
+++ b/middle_end/flambda2/simplify/flow/flow_types.mli
@@ -68,6 +68,7 @@ module Mutable_let_prim : sig
   type t =
     { bound_var : Variable.t;
       prim : Mutable_prim.t;
+      original_prim : Flambda_primitive.t;
       named_rewrite_id : Named_rewrite_id.t
     }
 

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -504,7 +504,9 @@ module Fold_prims = struct
           in
           let env =
             List.fold_left
-              (fun env T.Mutable_let_prim.{ named_rewrite_id; bound_var; prim } ->
+              (fun env
+                   T.Mutable_let_prim.
+                     { named_rewrite_id; bound_var; prim; original_prim = _ } ->
                 apply_prim ~dom ~non_escaping_blocks env named_rewrite_id
                   bound_var prim)
               env


### PR DESCRIPTION
We now use the `free_names` function from `Flambda_primitive` instead of a manual (and as it turns out, buggy) re-implementation.

This should fix a bug related to regions.