### PR TITLE
Fix a gadt typing bug introduced in the merge

### DIFF
--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -3273,6 +3273,8 @@ let add_gadt_equation uenv source destination =
     in
     add_jkind_equation ~reason:(Gadt_equation source)
       uenv destination jkind;
+    (* Adding a jkind equation may change the uenv. *)
+    let env = get_env uenv in
     let decl =
       new_local_type
         ~manifest_and_scope:(destination, expansion_scope)


### PR DESCRIPTION
This is a sad bug. `ctype` has always used a ref to old the environment, but now that's obscured a bit behind the "unification environment" such that we missed we were holding on to a stale value after the environment had been updated in `add_gadt_equation`.

I haven't added a test because I'm not sure of the current state of the test suite.  Hopefully there is already a test for this that we accidentally promoted.  If not we can add one.